### PR TITLE
fix(reference): Add Azure URL parsing and source URL building utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,22 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npm run ci
+      - name: Check code formatting
+        run: |
+          echo "Checking code formatting with Prettier..."
+          npm run format || {
+            echo "❌ Formatting issues found. Here are the differences:"
+            echo "Running 'npm run format:fix' to see what would change..."
+            npm run format:fix
+            echo "Git diff after formatting:"
+            git diff --name-only
+            git diff
+            exit 1
+          }
+      - run: npm run typecheck
+      - run: npm run lint  
+      - run: npm run test:coverage
+      - run: npm run build
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Copy code reference with Git provider source links as Markdown for sharing",
   "repository": "https://github.com/paulchiu/saucer-vscode",
   "publisher": "paulchiu",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.90.0"

--- a/src/test/stubs/vscode.ts
+++ b/src/test/stubs/vscode.ts
@@ -427,7 +427,8 @@ export class Range {
 /**
  * A symbol kind.
  */
-enum SymbolKind { // Use export enum for direct value access
+enum SymbolKind {
+  // Use export enum for direct value access
   File = 0,
   Module = 1,
   Namespace = 2,
@@ -459,7 +460,8 @@ enum SymbolKind { // Use export enum for direct value access
 /**
  * Symbol tags are extra annotations that tweak the rendering of a symbol.
  */
-enum SymbolTag { // Use export enum
+enum SymbolTag {
+  // Use export enum
   /**
    * Render a symbol as obsolete, usually using a strike-out.
    */

--- a/src/test/utils/azure.unit.test.ts
+++ b/src/test/utils/azure.unit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { parseAzureUrl, buildAzureSourceUrl } from '../../utils/azure'
+
+describe('parseAzureUrl', () => {
+  const sut = parseAzureUrl
+
+  it('should parse valid Azure DevOps URL', () => {
+    const url = 'https://dev.azure.com/myorg/myproject'
+    const result = sut(url)
+
+    expect(result).toEqual({
+      org: 'myorg',
+      project: 'myproject',
+    })
+  })
+
+  it('should parse Azure DevOps URL with trailing slash', () => {
+    const url = 'https://dev.azure.com/myorg/myproject/'
+    const result = sut(url)
+
+    expect(result).toEqual({
+      org: 'myorg',
+      project: 'myproject',
+    })
+  })
+
+  it('should parse Azure DevOps URL with additional path segments', () => {
+    const url = 'https://dev.azure.com/myorg/myproject/_git/repo'
+    const result = sut(url)
+
+    expect(result).toEqual({
+      org: 'myorg',
+      project: 'myproject',
+    })
+  })
+
+  it('should return undefined for invalid URL format', () => {
+    const url = 'https://github.com/owner/repo'
+    const result = sut(url)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined for malformed Azure URL', () => {
+    const url = 'https://dev.azure.com/myorg'
+    const result = sut(url)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined for non-HTTPS URL', () => {
+    const url = 'http://dev.azure.com/myorg/myproject'
+    const result = sut(url)
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('buildAzureSourceUrl', () => {
+  const sut = buildAzureSourceUrl
+
+  it('should build Azure source URL with line fragment', () => {
+    const url = 'https://dev.azure.com/myorg/myproject'
+    const branch = 'main'
+    const relativePath = 'src/file.ts'
+    const lineFragment = '#L10'
+
+    const result = sut(url, branch, relativePath, lineFragment)
+
+    expect(result).toBe(
+      'https://dev.azure.com/myorg/myproject/_git/myproject?path=src%2Ffile.ts&version=GBmain#L10'
+    )
+  })
+
+  it('should build Azure source URL without line fragment', () => {
+    const url = 'https://dev.azure.com/myorg/myproject'
+    const branch = 'develop'
+    const relativePath = 'README.md'
+    const lineFragment = ''
+
+    const result = sut(url, branch, relativePath, lineFragment)
+
+    expect(result).toBe(
+      'https://dev.azure.com/myorg/myproject/_git/myproject?path=README.md&version=GBdevelop'
+    )
+  })
+
+  it('should encode special characters in relative path', () => {
+    const url = 'https://dev.azure.com/myorg/myproject'
+    const branch = 'main'
+    const relativePath = 'src/components/my component.tsx'
+    const lineFragment = '#L5-L10'
+
+    const result = sut(url, branch, relativePath, lineFragment)
+
+    expect(result).toBe(
+      'https://dev.azure.com/myorg/myproject/_git/myproject?path=src%2Fcomponents%2Fmy%20component.tsx&version=GBmain#L5-L10'
+    )
+  })
+
+  it('should return undefined for invalid Azure URL', () => {
+    const url = 'https://github.com/owner/repo'
+    const branch = 'main'
+    const relativePath = 'src/file.ts'
+    const lineFragment = '#L10'
+
+    const result = sut(url, branch, relativePath, lineFragment)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should handle URL with additional path segments', () => {
+    const url = 'https://dev.azure.com/myorg/myproject/_git/repo'
+    const branch = 'feature/branch'
+    const relativePath = 'docs/api.md'
+    const lineFragment = '#L1'
+
+    const result = sut(url, branch, relativePath, lineFragment)
+
+    expect(result).toBe(
+      'https://dev.azure.com/myorg/myproject/_git/myproject?path=docs%2Fapi.md&version=GBfeature/branch#L1'
+    )
+  })
+})

--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -1,0 +1,31 @@
+export type AzureUrlInfo = {
+  org: string
+  project: string
+}
+
+export function parseAzureUrl(url: string): AzureUrlInfo | undefined {
+  const match = url.match(/https:\/\/dev\.azure\.com\/([^\/]+)\/([^\/]+)/)
+  if (!match) {
+    return undefined
+  }
+
+  const [, org, project] = match
+  return { org, project }
+}
+
+export function buildAzureSourceUrl(
+  url: string,
+  branch: string,
+  relativePath: string,
+  lineFragment: string
+): string | undefined {
+  const parsed = parseAzureUrl(url)
+  if (!parsed) {
+    return undefined
+  }
+
+  const { org, project } = parsed
+  return `https://dev.azure.com/${org}/${project}/_git/${project}?path=${encodeURIComponent(
+    relativePath
+  )}&version=GB${branch}${lineFragment}`
+}

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -77,7 +77,12 @@ export function toSourceLink(
         `[Bitbucket](${url}/src/${branch}/${reference.relativePath}${lineFragment})`
     )
     .with({ provider: 'azure' }, ({ url }) => {
-      const formattedUrl = buildAzureSourceUrl(url, branch, reference.relativePath, lineFragment)
+      const formattedUrl = buildAzureSourceUrl(
+        url,
+        branch,
+        reference.relativePath,
+        lineFragment
+      )
       return formattedUrl ? `[Azure DevOps](${formattedUrl})` : undefined
     })
     .with({ provider: 'generic' }, ({ url }) => `[source](${url})`)

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -76,15 +76,37 @@ export function toSourceLink(
         `[Bitbucket](${url}/src/${branch}/${reference.relativePath}${lineFragment})`
     )
     .with({ provider: 'azure' }, ({ url }) => {
-      const match = url.match(/https:\/\/dev\.azure\.com\/([^\/]+)\/([^\/]+)/)
-      if (match) {
-        const [_, org, project] = match
-        const formattedUrl = `https://dev.azure.com/${org}/${project}/_git/${project}?path=${encodeURIComponent(
-          reference.relativePath
-        )}&version=GB${branch}${lineFragment}`
-        return `[Azure DevOps](${formattedUrl})`
+      // Handle HTTPS format: https://dev.azure.com/org/project
+      let httpsMatch = url.match(
+        /https:\/\/dev\.azure\.com\/([^\/]+)\/([^\/]+)/
+      )
+
+      // Handle SSH format: git@ssh.dev.azure.com:v3/org/project/repo
+      let sshMatch = url.match(
+        /git@ssh\.dev\.azure\.com:v3\/([^\/]+)\/([^\/]+)\/([^\/]+)/
+      )
+
+      // Handle legacy visualstudio.com format: https://org.visualstudio.com/project
+      let legacyMatch = url.match(
+        /https:\/\/([^\.]+)\.visualstudio\.com\/([^\/]+)/
+      )
+
+      let org: string, project: string
+
+      if (httpsMatch) {
+        ;[, org, project] = httpsMatch
+      } else if (sshMatch) {
+        ;[, org, project] = sshMatch
+      } else if (legacyMatch) {
+        ;[, org, project] = legacyMatch
+      } else {
+        return undefined
       }
-      return undefined
+
+      const formattedUrl = `https://dev.azure.com/${org}/${project}/_git/${project}?path=${encodeURIComponent(
+        reference.relativePath
+      )}&version=GB${branch}${lineFragment}`
+      return `[Azure DevOps](${formattedUrl})`
     })
     .with({ provider: 'generic' }, ({ url }) => `[source](${url})`)
     .with({ provider: 'unknown' }, () => undefined)

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -76,33 +76,12 @@ export function toSourceLink(
         `[Bitbucket](${url}/src/${branch}/${reference.relativePath}${lineFragment})`
     )
     .with({ provider: 'azure' }, ({ url }) => {
-      // Handle HTTPS format: https://dev.azure.com/org/project
-      let httpsMatch = url.match(
-        /https:\/\/dev\.azure\.com\/([^\/]+)\/([^\/]+)/
-      )
-
-      // Handle SSH format: git@ssh.dev.azure.com:v3/org/project/repo
-      let sshMatch = url.match(
-        /git@ssh\.dev\.azure\.com:v3\/([^\/]+)\/([^\/]+)\/([^\/]+)/
-      )
-
-      // Handle legacy visualstudio.com format: https://org.visualstudio.com/project
-      let legacyMatch = url.match(
-        /https:\/\/([^\.]+)\.visualstudio\.com\/([^\/]+)/
-      )
-
-      let org: string, project: string
-
-      if (httpsMatch) {
-        ;[, org, project] = httpsMatch
-      } else if (sshMatch) {
-        ;[, org, project] = sshMatch
-      } else if (legacyMatch) {
-        ;[, org, project] = legacyMatch
-      } else {
+      const match = url.match(/https:\/\/dev\.azure\.com\/([^\/]+)\/([^\/]+)/)
+      if (!match) {
         return undefined
       }
 
+      const [, org, project] = match
       const formattedUrl = `https://dev.azure.com/${org}/${project}/_git/${project}?path=${encodeURIComponent(
         reference.relativePath
       )}&version=GB${branch}${lineFragment}`

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -6,6 +6,7 @@ import { fromSelection, ReferenceRange } from './referenceRange'
 import { getReferenceType, ReferenceType } from './referenceType'
 import { RemoteInfo } from './git'
 import { toProviderLineFragment } from './line'
+import { buildAzureSourceUrl } from './azure'
 
 export type Reference = {
   type: ReferenceType
@@ -76,16 +77,8 @@ export function toSourceLink(
         `[Bitbucket](${url}/src/${branch}/${reference.relativePath}${lineFragment})`
     )
     .with({ provider: 'azure' }, ({ url }) => {
-      const match = url.match(/https:\/\/dev\.azure\.com\/([^\/]+)\/([^\/]+)/)
-      if (!match) {
-        return undefined
-      }
-
-      const [, org, project] = match
-      const formattedUrl = `https://dev.azure.com/${org}/${project}/_git/${project}?path=${encodeURIComponent(
-        reference.relativePath
-      )}&version=GB${branch}${lineFragment}`
-      return `[Azure DevOps](${formattedUrl})`
+      const formattedUrl = buildAzureSourceUrl(url, branch, reference.relativePath, lineFragment)
+      return formattedUrl ? `[Azure DevOps](${formattedUrl})` : undefined
     })
     .with({ provider: 'generic' }, ({ url }) => `[source](${url})`)
     .with({ provider: 'unknown' }, () => undefined)


### PR DESCRIPTION
This pull request introduces new utilities for parsing Azure DevOps URLs and building source URLs to specific files and lines in Azure Repos. It includes unit tests to ensure the functionality is correct and robust.  

### Changes Made  

- **Added utility functions:**
  - `parseAzureUrl`: Parses Azure DevOps URLs to extract organization and project information.
  - `buildAzureSourceUrl`: Constructs a URL to a specific file in a repository on Azure DevOps, including the ability to specify line fragments.
  
- **Created unit tests**:
  - Tests for `parseAzureUrl` to verify proper parsing of valid URLs and handling of invalid formats.
  - Tests for `buildAzureSourceUrl` to ensure that URLs are generated correctly, including edge cases with special characters and line fragments.