### PR TITLE
feat(git): Add git root reference support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the "saucer" extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - Git root reference support and code improvements
+
+- Added support for referencing git root; useful when viewing subfolder
+
 ## [1.2.1] - Azure DevOps URL support
 
 - Fixed Azure DevOps URL parsing and source URL building utilities

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
           ],
           "default": "Ask",
           "description": "When referencing a selection, use"
+        },
+        "saucer.useGitRoot": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use git root for path calculations when available (improves accuracy for subdirectory workspaces)"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Copy code reference with Git provider source links as Markdown for sharing",
   "repository": "https://github.com/paulchiu/saucer-vscode",
   "publisher": "paulchiu",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.90.0"
@@ -25,6 +25,11 @@
           "type": "boolean",
           "default": true,
           "description": "References should include relative file path"
+        },
+        "saucer.useGitRoot": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use git root path to support working with subdirectories"
         },
         "saucer.linkSource": {
           "type": "boolean",
@@ -52,11 +57,6 @@
           ],
           "default": "Ask",
           "description": "When referencing a selection, use"
-        },
-        "saucer.useGitRoot": {
-          "type": "boolean",
-          "default": true,
-          "description": "Use git root for path calculations when available (improves accuracy for subdirectory workspaces)"
         }
       }
     },

--- a/src/test/utils/config.unit.test.ts
+++ b/src/test/utils/config.unit.test.ts
@@ -31,6 +31,7 @@ describe('getConfig', () => {
       linkSource: true,
       cursorRefType: 'Ask',
       selectionRefType: 'Ask',
+      useGitRoot: true,
     })
   })
 
@@ -42,6 +43,7 @@ describe('getConfig', () => {
           linkSource: false,
           cursorReferenceType: 'Line',
           selectionReferenceType: 'Range',
+          useGitRoot: false,
         }
         return values[key] ?? defaultValue
       }),
@@ -58,6 +60,7 @@ describe('getConfig', () => {
       linkSource: false,
       cursorRefType: 'Line',
       selectionRefType: 'Range',
+      useGitRoot: false,
     })
   })
 
@@ -83,6 +86,32 @@ describe('getConfig', () => {
       linkSource: true,
       cursorRefType: 'Ask',
       selectionRefType: 'Range',
+      useGitRoot: true,
+    })
+  })
+
+  it('should return useGitRoot as false when explicitly set', () => {
+    const disabledGitRootConfig = {
+      get: vi.fn().mockImplementation((key: string, defaultValue: any) => {
+        const values: Record<string, any> = {
+          useGitRoot: false,
+        }
+        return values[key] ?? defaultValue
+      }),
+    }
+    mockGetConfig.mockReturnValue(
+      disabledGitRootConfig as unknown as WorkspaceConfiguration
+    )
+
+    const result = sut()
+
+    expect(mockGetConfig).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      includeRelativePath: true,
+      linkSource: true,
+      cursorRefType: 'Ask',
+      selectionRefType: 'Ask',
+      useGitRoot: false,
     })
   })
 })

--- a/src/test/utils/git.unit.test.ts
+++ b/src/test/utils/git.unit.test.ts
@@ -312,7 +312,9 @@ describe('utils/git', () => {
     })
 
     it('should return undefined when not in git repository', async () => {
-      mockExecAsync.mockRejectedValueOnce(new Error('fatal: not a git repository'))
+      mockExecAsync.mockRejectedValueOnce(
+        new Error('fatal: not a git repository')
+      )
 
       const result = await sut('/different/path')
 
@@ -368,7 +370,9 @@ describe('utils/git', () => {
 
     it('should handle workspace outside git repository', async () => {
       const nonGitPath = '/non/git/workspace'
-      mockExecAsync.mockRejectedValueOnce(new Error('fatal: not a git repository'))
+      mockExecAsync.mockRejectedValueOnce(
+        new Error('fatal: not a git repository')
+      )
 
       const result = await sut(nonGitPath)
 

--- a/src/test/utils/git.unit.test.ts
+++ b/src/test/utils/git.unit.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   getRemoteInfo,
   getCurrentBranch,
+  findGitRoot,
+  getGitContext,
+  __clearGitRootCache,
   type RemoteInfo,
+  type GitContext,
 } from '../../utils/git'
 import { execAsync } from '../../utils/exec'
 
@@ -287,6 +291,171 @@ describe('utils/git', () => {
           expect(result).toHaveProperty('provider', 'azure')
         }
       )
+    })
+  })
+
+  describe('findGitRoot', () => {
+    const sut = findGitRoot
+
+    beforeEach(() => {
+      // Clear the cache before each test to ensure isolation
+      __clearGitRootCache()
+    })
+
+    it('should return git root path when in git repository', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '/Users/test/project\n',
+        stderr: '',
+      })
+
+      const result = await sut(testWorkspacePath)
+
+      expect(result).toBe('/Users/test/project')
+      expect(mockExecAsync).toHaveBeenCalledWith(
+        'git rev-parse --show-toplevel',
+        { cwd: testWorkspacePath }
+      )
+    })
+
+    it('should return undefined when not in git repository', async () => {
+      mockExecAsync.mockRejectedValueOnce(new Error('fatal: not a git repository'))
+
+      const result = await sut('/different/path')
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when git command returns empty output', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '',
+        stderr: '',
+      })
+
+      const result = await sut('/empty/path')
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should cache results for performance', async () => {
+      const cachePath = '/cache/test'
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '/Users/test/project\n',
+        stderr: '',
+      })
+
+      // First call should execute git command
+      const result1 = await sut(cachePath)
+      expect(result1).toBe('/Users/test/project')
+      expect(mockExecAsync).toHaveBeenCalledTimes(1)
+
+      // Second call should use cached result
+      const result2 = await sut(cachePath)
+      expect(result2).toBe('/Users/test/project')
+      expect(mockExecAsync).toHaveBeenCalledTimes(1) // No additional calls
+    })
+
+    it('should cache failure results to avoid repeated attempts', async () => {
+      const failPath = '/fail/path'
+      mockExecAsync.mockRejectedValueOnce(new Error('fatal: not a git repository'))
+
+      // First call should attempt git command
+      const result1 = await sut(failPath)
+      expect(result1).toBeUndefined()
+      expect(mockExecAsync).toHaveBeenCalledTimes(1)
+
+      // Second call should use cached failure result
+      const result2 = await sut(failPath)
+      expect(result2).toBeUndefined()
+      expect(mockExecAsync).toHaveBeenCalledTimes(1) // No additional calls
+    })
+  })
+
+  describe('getGitContext', () => {
+    const sut = getGitContext
+
+    beforeEach(() => {
+      // Clear cache before each test
+      __clearGitRootCache()
+      vi.resetAllMocks()
+    })
+
+    it('should provide git context when in git repository at root level', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '/Users/test/project\n',
+        stderr: '',
+      })
+
+      const result = await sut('/Users/test/project')
+
+      const expected: GitContext = {
+        workspacePath: '/Users/test/project',
+        gitRoot: '/Users/test/project',
+        relativePath: undefined, // workspace is at git root
+      }
+      expect(result).toEqual(expected)
+    })
+
+    it('should provide git context when in git repository subdirectory', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '/Users/test/project\n',
+        stderr: '',
+      })
+
+      const result = await sut('/Users/test/project/frontend')
+
+      const expected: GitContext = {
+        workspacePath: '/Users/test/project/frontend',
+        gitRoot: '/Users/test/project',
+        relativePath: 'frontend',
+      }
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle workspace outside git repository', async () => {
+      const nonGitPath = '/non/git/workspace'
+      mockExecAsync.mockRejectedValueOnce(new Error('fatal: not a git repository'))
+
+      const result = await sut(nonGitPath)
+
+      const expected: GitContext = {
+        workspacePath: nonGitPath,
+        gitRoot: undefined,
+        relativePath: undefined,
+      }
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle nested subdirectories correctly', async () => {
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '/Users/test/project\n',
+        stderr: '',
+      })
+
+      const result = await sut('/Users/test/project/apps/frontend/src')
+
+      const expected: GitContext = {
+        workspacePath: '/Users/test/project/apps/frontend/src',
+        gitRoot: '/Users/test/project',
+        relativePath: 'apps/frontend/src',
+      }
+      expect(result).toEqual(expected)
+    })
+
+    it('should handle workspace outside of git root gracefully', async () => {
+      const workspacePath = '/Users/test/other/project'
+      mockExecAsync.mockResolvedValueOnce({
+        stdout: '/Users/test/different-project\n',
+        stderr: '',
+      })
+
+      const result = await sut(workspacePath)
+
+      const expected: GitContext = {
+        workspacePath: workspacePath,
+        gitRoot: '/Users/test/different-project',
+        relativePath: undefined, // workspace is outside git root
+      }
+      expect(result).toEqual(expected)
     })
   })
 })

--- a/src/test/utils/git.unit.test.ts
+++ b/src/test/utils/git.unit.test.ts
@@ -4,7 +4,6 @@ import {
   getCurrentBranch,
   findGitRoot,
   getGitContext,
-  __clearGitRootCache,
   type RemoteInfo,
   type GitContext,
 } from '../../utils/git'
@@ -297,11 +296,6 @@ describe('utils/git', () => {
   describe('findGitRoot', () => {
     const sut = findGitRoot
 
-    beforeEach(() => {
-      // Clear the cache before each test to ensure isolation
-      __clearGitRootCache()
-    })
-
     it('should return git root path when in git repository', async () => {
       mockExecAsync.mockResolvedValueOnce({
         stdout: '/Users/test/project\n',
@@ -335,49 +329,10 @@ describe('utils/git', () => {
 
       expect(result).toBeUndefined()
     })
-
-    it('should cache results for performance', async () => {
-      const cachePath = '/cache/test'
-      mockExecAsync.mockResolvedValueOnce({
-        stdout: '/Users/test/project\n',
-        stderr: '',
-      })
-
-      // First call should execute git command
-      const result1 = await sut(cachePath)
-      expect(result1).toBe('/Users/test/project')
-      expect(mockExecAsync).toHaveBeenCalledTimes(1)
-
-      // Second call should use cached result
-      const result2 = await sut(cachePath)
-      expect(result2).toBe('/Users/test/project')
-      expect(mockExecAsync).toHaveBeenCalledTimes(1) // No additional calls
-    })
-
-    it('should cache failure results to avoid repeated attempts', async () => {
-      const failPath = '/fail/path'
-      mockExecAsync.mockRejectedValueOnce(new Error('fatal: not a git repository'))
-
-      // First call should attempt git command
-      const result1 = await sut(failPath)
-      expect(result1).toBeUndefined()
-      expect(mockExecAsync).toHaveBeenCalledTimes(1)
-
-      // Second call should use cached failure result
-      const result2 = await sut(failPath)
-      expect(result2).toBeUndefined()
-      expect(mockExecAsync).toHaveBeenCalledTimes(1) // No additional calls
-    })
   })
 
   describe('getGitContext', () => {
     const sut = getGitContext
-
-    beforeEach(() => {
-      // Clear cache before each test
-      __clearGitRootCache()
-      vi.resetAllMocks()
-    })
 
     it('should provide git context when in git repository at root level', async () => {
       mockExecAsync.mockResolvedValueOnce({

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,7 @@ export type Config = {
   linkSource: boolean
   cursorRefType: string
   selectionRefType: string
+  useGitRoot: boolean
 }
 
 export function getConfig(): Config {
@@ -13,11 +14,13 @@ export function getConfig(): Config {
   const linkSource = config.get<boolean>('linkSource', true)
   const cursorRefType = config.get<string>('cursorReferenceType', 'Ask')
   const selectionRefType = config.get<string>('selectionReferenceType', 'Ask')
+  const useGitRoot = config.get<boolean>('useGitRoot', true)
 
   return {
     includeRelativePath,
     linkSource,
     cursorRefType,
     selectionRefType,
+    useGitRoot,
   }
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,5 +1,6 @@
 import { match } from 'ts-pattern'
 import { execAsync } from './exec'
+import * as path from 'path'
 
 export type GitProvider =
   | 'github'
@@ -14,6 +15,72 @@ export type RemoteInfo =
       url: string
     }
   | { provider: 'unknown' }
+
+export type GitContext = {
+  gitRoot?: string
+  workspacePath: string
+  relativePath?: string
+}
+
+const gitRootCache = new Map<string, string | undefined>()
+
+// Export cache clearing function for testing
+export function __clearGitRootCache(): void {
+  gitRootCache.clear()
+}
+
+export async function findGitRoot(
+  startPath: string
+): Promise<string | undefined> {
+  // Check cache first
+  const cachedResult = gitRootCache.get(startPath)
+  if (cachedResult !== undefined) {
+    return cachedResult === '' ? undefined : cachedResult
+  }
+
+  try {
+    const { stdout } = await execAsync('git rev-parse --show-toplevel', {
+      cwd: startPath,
+    })
+
+    const gitRoot = stdout.trim()
+    if (gitRoot) {
+      gitRootCache.set(startPath, gitRoot)
+      return gitRoot
+    }
+  } catch (_error) {
+    // Cache failures to avoid repeated attempts
+    gitRootCache.set(startPath, '')
+  }
+
+  return undefined
+}
+
+export async function getGitContext(
+  workspacePath: string
+): Promise<GitContext> {
+  const gitRoot = await findGitRoot(workspacePath)
+
+  const context: GitContext = {
+    workspacePath,
+    gitRoot,
+  }
+
+  // Calculate relative path from git root to workspace if both are available
+  if (gitRoot && workspacePath) {
+    try {
+      const relativePath = path.relative(gitRoot, workspacePath)
+      // Only set relativePath if workspace is actually within git root
+      if (relativePath && !relativePath.startsWith('..')) {
+        context.relativePath = relativePath === '.' ? undefined : relativePath
+      }
+    } catch (_error) {
+      // Path calculation failed, leave relativePath undefined
+    }
+  }
+
+  return context
+}
 
 function isValidGitUrl(url: string): boolean {
   // Handle SSH URLs (git@github.com:user/repo.git)

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -44,16 +44,15 @@ export async function getReference(
       gitRoot = gitContext.gitRoot
 
       if (gitRoot) {
-        // Calculate path from git root to the current file
-        const absoluteFilePath = path.resolve(folder?.uri.fsPath || '', relativePath)
+        const absoluteFilePath = path.resolve(
+          folder?.uri.fsPath || '',
+          relativePath
+        )
         pathFromGitRoot = path.relative(gitRoot, absoluteFilePath)
-        
-        // Ensure we use forward slashes for consistency across platforms
         pathFromGitRoot = pathFromGitRoot.replace(/\\/g, '/')
       }
     } catch (_error) {
       // Git operations failed, continue with workspace-relative paths
-      // gitRoot and pathFromGitRoot remain undefined
     }
   }
 
@@ -86,8 +85,6 @@ export function toSourceLink(
   reference: Reference
 ): string | undefined {
   const lineFragment = toProviderLineFragment(remoteInfo, reference)
-  
-  // Use git-relative path when available, otherwise fall back to workspace-relative path
   const referencePath = reference.pathFromGitRoot || reference.relativePath
 
   return match(remoteInfo)


### PR DESCRIPTION
This pull request introduces support for referencing the git root when determining path location.

## Changes

- **New Feature**: Added support for referencing the git root.
  - This feature is especially useful when working within subdirectories, allowing users to have relative paths that are correctly resolved based on the git repository root.

- **Updates to the Configuration**:
  - Introduced a new configuration option `saucer.useGitRoot` to toggle the use of git root path, defaulting to `true`.