### PR TITLE
fix(azure): Update Azure URL to support line highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the "saucer" extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - Fixed line referencing and highlighting for Azure DevOps
+
+- Fixed issue where Azure references would only link to file and not line(s)
+
 ## [1.3.0] - Git root reference support and code improvements
 
 - Added support for referencing git root; useful when viewing subfolder

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Copy code reference with Git provider source links as Markdown for sharing",
   "repository": "https://github.com/paulchiu/saucer-vscode",
   "publisher": "paulchiu",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.90.0"

--- a/src/test/utils/azure.unit.test.ts
+++ b/src/test/utils/azure.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { parseAzureUrl, buildAzureSourceUrl } from '../../utils/azure'
+import {
+  parseAzureUrl,
+  buildAzureSourceUrl,
+  AZURE_LINE_HIGHLIGHT_SNIPPET,
+} from '../../utils/azure'
 
 describe('parseAzureUrl', () => {
   const sut = parseAzureUrl
@@ -68,7 +72,7 @@ describe('buildAzureSourceUrl', () => {
     const result = sut(url, branch, relativePath, lineFragment)
 
     expect(result).toBe(
-      'https://dev.azure.com/myorg/myproject/_git/myproject?path=src%2Ffile.ts&version=GBmain#L10'
+      `https://dev.azure.com/myorg/myproject/_git/myproject?path=src%2Ffile.ts&version=GBmain#L10${AZURE_LINE_HIGHLIGHT_SNIPPET}`
     )
   })
 
@@ -81,7 +85,7 @@ describe('buildAzureSourceUrl', () => {
     const result = sut(url, branch, relativePath, lineFragment)
 
     expect(result).toBe(
-      'https://dev.azure.com/myorg/myproject/_git/myproject?path=README.md&version=GBdevelop'
+      `https://dev.azure.com/myorg/myproject/_git/myproject?path=README.md&version=GBdevelop${AZURE_LINE_HIGHLIGHT_SNIPPET}`
     )
   })
 
@@ -94,7 +98,7 @@ describe('buildAzureSourceUrl', () => {
     const result = sut(url, branch, relativePath, lineFragment)
 
     expect(result).toBe(
-      'https://dev.azure.com/myorg/myproject/_git/myproject?path=src%2Fcomponents%2Fmy%20component.tsx&version=GBmain#L5-L10'
+      `https://dev.azure.com/myorg/myproject/_git/myproject?path=src%2Fcomponents%2Fmy%20component.tsx&version=GBmain#L5-L10${AZURE_LINE_HIGHLIGHT_SNIPPET}`
     )
   })
 
@@ -118,7 +122,7 @@ describe('buildAzureSourceUrl', () => {
     const result = sut(url, branch, relativePath, lineFragment)
 
     expect(result).toBe(
-      'https://dev.azure.com/myorg/myproject/_git/myproject?path=docs%2Fapi.md&version=GBfeature/branch#L1'
+      `https://dev.azure.com/myorg/myproject/_git/myproject?path=docs%2Fapi.md&version=GBfeature/branch#L1${AZURE_LINE_HIGHLIGHT_SNIPPET}`
     )
   })
 })

--- a/src/test/utils/line.unit.test.ts
+++ b/src/test/utils/line.unit.test.ts
@@ -25,7 +25,7 @@ describe('utils/line', () => {
       ${'github'}    | ${42}      | ${'#L42'}
       ${'gitlab'}    | ${42}      | ${'#L42'}
       ${'bitbucket'} | ${42}      | ${'#lines-42'}
-      ${'azure'}     | ${42}      | ${'&line=42&lineEnd=42'}
+      ${'azure'}     | ${42}      | ${'&line=42&lineEnd=43'}
       ${'generic'}   | ${42}      | ${''}
     `(
       'cursor line formatting for $provider',
@@ -48,7 +48,7 @@ describe('utils/line', () => {
       ${'github'}    | ${10}     | ${20}   | ${'#L10-L20'}
       ${'gitlab'}    | ${10}     | ${20}   | ${'#L10-20'}
       ${'bitbucket'} | ${10}     | ${20}   | ${'#lines-10:20'}
-      ${'azure'}     | ${10}     | ${20}   | ${'&line=10&lineEnd=20'}
+      ${'azure'}     | ${10}     | ${20}   | ${'&line=10&lineEnd=21'}
       ${'generic'}   | ${10}     | ${20}   | ${''}
     `(
       'selection line formatting for $provider',

--- a/src/test/utils/reference.unit.test.ts
+++ b/src/test/utils/reference.unit.test.ts
@@ -5,6 +5,7 @@ import { getReferenceType, ReferenceType } from '../../utils/referenceType'
 import { fromSelection } from '../../utils/referenceRange'
 import { toProviderLineFragment } from '../../utils/line'
 import { RemoteInfo } from '../../utils/git'
+import { AZURE_LINE_HIGHLIGHT_SNIPPET } from '../../utils/azure'
 
 // Mock dependencies
 vi.mock('../../utils/context', () => ({
@@ -35,6 +36,7 @@ describe('utils/reference', () => {
       linkSource: true,
       cursorRefType: 'Symbol',
       selectionRefType: 'Ask',
+      useGitRoot: false,
     }
 
     it('should return reference with cursor type when range kind is cursor', async () => {
@@ -202,7 +204,7 @@ describe('utils/reference', () => {
       const result = sut(remoteInfo, mockBranch, mockReference)
 
       expect(result).toBe(
-        '[Azure DevOps](https://dev.azure.com/organization/project/_git/project?path=src%2Futils%2Ffile.ts&version=GBmain#L10)'
+        `[Azure DevOps](https://dev.azure.com/organization/project/_git/project?path=src%2Futils%2Ffile.ts&version=GBmain#L10${AZURE_LINE_HIGHLIGHT_SNIPPET})`
       )
     })
 

--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -13,6 +13,9 @@ export function parseAzureUrl(url: string): AzureUrlInfo | undefined {
   return { org, project }
 }
 
+export const AZURE_LINE_HIGHLIGHT_SNIPPET =
+  '&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents'
+
 export function buildAzureSourceUrl(
   url: string,
   branch: string,
@@ -27,5 +30,5 @@ export function buildAzureSourceUrl(
   const { org, project } = parsed
   return `https://dev.azure.com/${org}/${project}/_git/${project}?path=${encodeURIComponent(
     relativePath
-  )}&version=GB${branch}${lineFragment}`
+  )}&version=GB${branch}${lineFragment}${AZURE_LINE_HIGHLIGHT_SNIPPET}`
 }

--- a/src/utils/line.ts
+++ b/src/utils/line.ts
@@ -9,7 +9,7 @@ function toProviderCursorLine(provider: GitProvider, line: number): string {
     .with('github', () => `#L${line}`)
     .with('gitlab', () => `#L${line}`)
     .with('bitbucket', () => `#lines-${line}`)
-    .with('azure', () => `&line=${line}&lineEnd=${line}`)
+    .with('azure', () => `&line=${line}&lineEnd=${line + 1}`)
     .with('generic', () => '')
     .exhaustive()
 }
@@ -23,7 +23,7 @@ function toProviderSelectionLines(
     .with('github', () => `#L${startLine}-L${endLine}`)
     .with('gitlab', () => `#L${startLine}-${endLine}`)
     .with('bitbucket', () => `#lines-${startLine}:${endLine}`)
-    .with('azure', () => `&line=${startLine}&lineEnd=${endLine}`)
+    .with('azure', () => `&line=${startLine}&lineEnd=${endLine + 1}`)
     .with('generic', () => '')
     .exhaustive()
 }


### PR DESCRIPTION
This PR addresses issues with line referencing and highlighting for Azure DevOps links in the project. The following changes have been made:

- **Azure Utils Update**: Introduced a constant `AZURE_LINE_HIGHLIGHT_SNIPPET` to append the correct line highlighting parameters in the `buildAzureSourceUrl` function in `src/utils/azure.ts`.